### PR TITLE
Use xcolor; load cleveref after amsmath

### DIFF
--- a/ledger.cls
+++ b/ledger.cls
@@ -51,7 +51,7 @@
                       % width
 \RequirePackage{framed}
 
-\RequirePackage{color} % used to change color of text
+\RequirePackage{xcolor} % used to change color of text
 
 \RequirePackage{fancyhdr} % Allows customization of headers/footers
 \renewcommand{\headrulewidth}{0pt}
@@ -140,7 +140,7 @@
 
 \RequirePackage{caption} % Allows customization of captions
 
-\RequirePackage{cleveref} % Used for 'smart' references
+
 
 
 
@@ -157,6 +157,8 @@
 \RequirePackage{endnotes} % Used for making endnotes
 
 \RequirePackage{amsmath,amssymb} % Math
+
+\RequirePackage{cleveref} % Used for 'smart' references
 
 \RequirePackage{listings} % Code
 \lstset{breaklines=true,basicstyle=\ttfamily\fontsize{10pt}{11pt}\selectfont,xleftmargin=1.2cm,breakindent=.6cm}


### PR DESCRIPTION
Two minor errors I found when using the template.

1. color "gray" is unrecognized with color package. switched to xcolor instead.

2. error when loading cleveref before amsmath. says that cleveref must be loaded after amsmath.